### PR TITLE
R4R: Move invariant to invariant package

### DIFF
--- a/app/v0/invariants.go
+++ b/app/v0/invariants.go
@@ -3,19 +3,19 @@ package v0
 import (
 	"fmt"
 
-	"github.com/irisnet/irishub/modules/bank"
-	distr "github.com/irisnet/irishub/modules/distribution"
-	"github.com/irisnet/irishub/modules/stake"
+	bankInvariant "github.com/irisnet/irishub/modules/bank/invariants"
+	distrInvariant "github.com/irisnet/irishub/modules/distribution/invariants"
+	stakeInvariant "github.com/irisnet/irishub/modules/stake/invariants"
 	sdk "github.com/irisnet/irishub/types"
 )
 
 func (p *ProtocolV0) runtimeInvariants() []sdk.Invariant {
 	return []sdk.Invariant{
-		bank.NonnegativeBalanceInvariant(p.accountMapper),
-		distr.ValAccumInvariants(p.distrKeeper, p.StakeKeeper),
-		stake.SupplyInvariants(p.bankKeeper, p.StakeKeeper,
+		bankInvariant.NonnegativeBalanceInvariant(p.accountMapper),
+		distrInvariant.ValAccumInvariants(p.distrKeeper, p.StakeKeeper),
+		stakeInvariant.SupplyInvariants(p.bankKeeper, p.StakeKeeper,
 			p.feeKeeper, p.distrKeeper, p.accountMapper),
-		stake.PositivePowerInvariant(p.StakeKeeper),
+		stakeInvariant.PositivePowerInvariant(p.StakeKeeper),
 	}
 }
 

--- a/modules/bank/invariants/invariants.go
+++ b/modules/bank/invariants/invariants.go
@@ -1,4 +1,4 @@
-package bank
+package invariants
 
 import (
 	"errors"

--- a/modules/bank/simulation/sim_test.go
+++ b/modules/bank/simulation/sim_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/irisnet/irishub/modules/mock"
 	"github.com/irisnet/irishub/modules/mock/simulation"
 	stakeTypes "github.com/irisnet/irishub/modules/stake/types"
+	"github.com/irisnet/irishub/modules/bank/invariants"
 )
 
 func TestBankWithRandomMessages(t *testing.T) {
@@ -38,8 +39,8 @@ func TestBankWithRandomMessages(t *testing.T) {
 		},
 		[]simulation.RandSetup{},
 		[]simulation.Invariant{
-			bank.NonnegativeBalanceInvariant(mapper),
-			bank.TotalCoinsInvariant(mapper, func() sdk.Coins { return mapp.TotalCoinsSupply }),
+			invariants.NonnegativeBalanceInvariant(mapper),
+			invariants.TotalCoinsInvariant(mapper, func() sdk.Coins { return mapp.TotalCoinsSupply }),
 		},
 		30, 60,
 		false,

--- a/modules/distribution/invariants/invariants.go
+++ b/modules/distribution/invariants/invariants.go
@@ -1,15 +1,16 @@
-package distribution
+package invariants
 
 import (
 	"fmt"
 
 	sdk "github.com/irisnet/irishub/types"
+	distr "github.com/irisnet/irishub/modules/distribution"
 	"github.com/irisnet/irishub/modules/mock/simulation"
 )
 
 // AllInvariants runs all invariants of the distribution module
 // Currently: total supply, positive power
-func AllInvariants(d Keeper, sk StakeKeeper) simulation.Invariant {
+func AllInvariants(d distr.Keeper, sk distr.StakeKeeper) simulation.Invariant {
 	return func(ctx sdk.Context) error {
 		err := ValAccumInvariants(d, sk)(ctx)
 		if err != nil {
@@ -20,13 +21,13 @@ func AllInvariants(d Keeper, sk StakeKeeper) simulation.Invariant {
 }
 
 // ValAccumInvariants checks that the fee pool accum == sum all validators' accum
-func ValAccumInvariants(k Keeper, sk StakeKeeper) simulation.Invariant {
+func ValAccumInvariants(k distr.Keeper, sk distr.StakeKeeper) simulation.Invariant {
 
 	return func(ctx sdk.Context) error {
 		height := ctx.BlockHeight()
 
 		valAccum := sdk.ZeroDec()
-		k.IterateValidatorDistInfos(ctx, func(_ int64, vdi ValidatorDistInfo) bool {
+		k.IterateValidatorDistInfos(ctx, func(_ int64, vdi distr.ValidatorDistInfo) bool {
 			lastValPower := sk.GetLastValidatorPower(ctx, vdi.OperatorAddr)
 			valAccum = valAccum.Add(vdi.GetValAccum(height, sdk.NewDecFromInt(lastValPower)))
 			return false

--- a/modules/gov/invariants/invariants.go
+++ b/modules/gov/invariants/invariants.go
@@ -1,4 +1,4 @@
-package gov
+package invariants
 
 import (
 	sdk "github.com/irisnet/irishub/types"

--- a/modules/gov/simulation/sim_test.go
+++ b/modules/gov/simulation/sim_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/irisnet/irishub/modules/mock/simulation"
 	distr "github.com/irisnet/irishub/modules/distribution"
 	"github.com/irisnet/irishub/modules/guardian"
+	"github.com/irisnet/irishub/modules/gov/invariants"
 )
 
 // TestGovWithRandomMessages
@@ -111,7 +112,7 @@ func TestGovWithRandomMessages(t *testing.T) {
 		}, []simulation.RandSetup{
 			setup,
 		}, []simulation.Invariant{
-			gov.AllInvariants(),
+			invariants.AllInvariants(),
 		}, 10, 100,
 		false,
 	)

--- a/modules/slashing/invariants/invariants.go
+++ b/modules/slashing/invariants/invariants.go
@@ -1,4 +1,4 @@
-package slashing
+package invariants
 
 import (
 	"github.com/irisnet/irishub/modules/mock/simulation"

--- a/modules/stake/invariants/invariants.go
+++ b/modules/stake/invariants/invariants.go
@@ -1,4 +1,4 @@
-package stake
+package invariants
 
 import (
 	"bytes"


### PR DESCRIPTION
To solve the cycle import issue, I just move invariants.go from root directory of each module to invariants package, for instance:
```
modules/bank/invariants.go → modules/bank/invariants/invariants.go
```
Later, I will improve invariants checking coverage for some modules, such as distribution: https://github.com/irisnet/irishub/issues/1026